### PR TITLE
Fail silently for admin mail notification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ coverage: build ## check code coverage
 build: ## Build app database and static content in build directory
 	mkdir -p build/whoosh_index
 	mkdir -p build/media
+	# should fix errors upon calling python manage.py commands
+	pip uninstall python-openid -y
+	pip uninstall python3-openid -y
+	pip install python3-openid
 	python manage.py makemigrations apps --noinput
 	python manage.py makemigrations backend --noinput
 	python manage.py makemigrations download --noinput

--- a/settings/admin_email_handler.py
+++ b/settings/admin_email_handler.py
@@ -1,0 +1,9 @@
+from django.utils.log import AdminEmailHandler
+from django.core import mail
+
+# extends default admin email handler
+class CustomEmailHandler(AdminEmailHandler):
+    def send_mail(self, subject, message, *args, **kwargs):
+        # set fail_silently true before proceeding
+        kwargs["fail_silently"] = False
+        return super().send_mail(subject, message, *args, **kwargs)

--- a/settings/base.py
+++ b/settings/base.py
@@ -131,11 +131,13 @@ LOGGING = {
         'mail_admins': {
             'level': 'ERROR',
             'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
+            # 'class': 'django.utils.log.AdminEmailHandler'
+            'class': 'settings.admin_email_handler.CustomEmailHandler'
         },
         'mail_admins_always': {
             'level': 'ERROR',
-            'class': 'django.utils.log.AdminEmailHandler'
+            # 'class': 'django.utils.log.AdminEmailHandler'
+            'class': 'settings.admin_email_handler.CustomEmailHandler'
         },
         'console': {
             'level': 'INFO',


### PR DESCRIPTION
Hello @coleslaw481 , would this address #99?

- Instead of the whole logger having fail_silently set to true, I think only sending emails to admins upon receiving an error log should fail silently.
- So I tried setting it true before the send_mail function gets called inside the default AdminEmailHandler, by extending that class.