### PR TITLE
Fix: Restrict search indexing to active apps only

### DIFF
--- a/apps/search_indexes.py
+++ b/apps/search_indexes.py
@@ -32,7 +32,9 @@ class AppIndex(indexes.SearchIndex, indexes.Indexable):
     def get_model(self):
         return App
 
-
+    def index_queryset(self, using=None):
+        return self.get_model().objects.filter(active=True)
+    
 class AuthorIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.EdgeNgramField(document = True, use_template = True)
     name = indexes.CharField(model_attr = 'name')

--- a/apps/search_indexes.py
+++ b/apps/search_indexes.py
@@ -34,7 +34,8 @@ class AppIndex(indexes.SearchIndex, indexes.Indexable):
 
     def index_queryset(self, using=None):
         return self.get_model().objects.filter(active=True)
-    
+
+
 class AuthorIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.EdgeNgramField(document = True, use_template = True)
     name = indexes.CharField(model_attr = 'name')

--- a/apps/tests.py
+++ b/apps/tests.py
@@ -12,6 +12,7 @@ import tempfile
 import random
 from PIL import Image, ImageDraw
 
+from apps.search_indexes import AppIndex
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.auth.models import User
@@ -677,3 +678,31 @@ class AppButtonsTestCase(TestCase):
         appobj.save()
         res = app_buttons.app_button_by_name('myapp')
         self.assertEqual('myapp', res['app'].name)
+
+
+class AppIndexQuerysetTestCase(TestCase):
+
+    def setUp(self):
+        App.objects.all().delete()
+
+        self.active_app = App.objects.create(
+            name='activeapp',
+            fullname='ActiveApp',
+            active=True
+        )
+
+        self.inactive_app = App.objects.create(
+            name='inactiveapp',
+            fullname='InactiveApp',
+            active=False
+        )
+
+    def tearDown(self):
+        App.objects.all().delete()
+
+    def test_index_queryset_returns_only_active_apps(self):
+        index = AppIndex()
+        queryset = index.index_queryset()
+
+        self.assertIn(self.active_app, queryset)
+        self.assertNotIn(self.inactive_app, queryset)


### PR DESCRIPTION
This PR ensures that only active apps are indexed by Haystack by implementing index_queryset() in AppIndex.

Previously, inactive apps could appear in search results.
This change filters the index to App.objects.filter(active=True).

Related Issue - #114 