### PR TITLE
fix: resolve file descriptor leak in process_jar using context managers

### DIFF
--- a/submit_app/processjar.py
+++ b/submit_app/processjar.py
@@ -35,9 +35,11 @@ def process_jar(jar_file, expect_app_name):
         LOGGER.info('User uploaded invalid jar file: ' + str(bzf))
         raise ValueError('is not a valid zip file')
 
-    manifest_file = archive.read(_MANIFEST_FILE_NAME)
-    manifest = parse_manifest(manifest_file)
-    archive.close()
+    # FIX: Context manager guarantees the ZipFile is closed 
+    # and the file descriptor is released even if an exception occurs
+    with archive:
+        manifest_file = archive.read(_MANIFEST_FILE_NAME)
+        manifest = parse_manifest(manifest_file)
 
     is_osgi_bundle = True if manifest.main_section[b'Bundle-SymbolicName'] else False
     parser_func = _parse_osgi_bundle # if is_osgi_bundle else _parse_simple_app


### PR DESCRIPTION
### Description
This PR resolves the file descriptor leak in the manifest parsing logic that contributes to WSGI worker exhaustion and "too many open files" server outages.

The fix transitions the zip archive handling in `submit_app/processjar.py` to a Python context manager (`with` statement). This guarantees that the operating system immediately releases the file handler as soon as the manifest is read, even if a subsequent parsing error triggers an exception.

### Related Issue
Fixes #120 

### Testing & Proof
I verified this fix locally on macOS by profiling the Python process with `lsof` while simulating a loop of 500 malformed app uploads.

* **Before Fix:** The process leaked over 500 file descriptors, reaching a peak of **552**.
* **After Fix:** The file descriptor count remained completely stable at **52** throughout the entire 500-upload loop.

**Before and After Profiling Comparison:**
<img width="887" height="138" alt="Screenshot 2026-03-05 at 11 19 56 AM" src="https://github.com/user-attachments/assets/6be7b305-70b0-42e9-b5c3-bd42fad5889d" />

Implementing this strict context management prevents resource exhaustion and improves the resilience of the submission pipeline.