### PR TITLE
FIX #122: create build/appstore/ migration dirs in Makefile build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,14 @@ coverage: build ## check code coverage
 build: ## Build app database and static content in build directory
 	mkdir -p build/whoosh_index
 	mkdir -p build/media
+	mkdir -p build/appstore/apps
+	mkdir -p build/appstore/download
+	mkdir -p build/appstore/submit_app
+	touch build/__init__.py
+	touch build/appstore/__init__.py
+	touch build/appstore/apps/__init__.py
+	touch build/appstore/download/__init__.py
+	touch build/appstore/submit_app/__init__.py
 	# should fix errors upon calling python manage.py commands
 	pip uninstall python-openid -y
 	pip uninstall python3-openid -y


### PR DESCRIPTION

This pull request updates the build process in the `Makefile` to better support the app store structure by creating necessary directories and `__init__.py` files. This helps ensure Python recognizes these directories as packages and prevents potential import errors.

## Build process improvements:

* Modified the `build` target in the `Makefile` to create new directories for `appstore/apps`, `appstore/download`, and `appstore/submit_app` under the `build` directory, and to add corresponding `__init__.py` files to each directory and subdirectory to establish them as Python packages.

## Related Issues
- #122 