### PR TITLE
Fix: exclude inactive apps from search index

### DIFF
--- a/apps/search_indexes.py
+++ b/apps/search_indexes.py
@@ -32,6 +32,9 @@ class AppIndex(indexes.SearchIndex, indexes.Indexable):
     def get_model(self):
         return App
 
+    def index_queryset(self, using=None):
+        return self.get_model().objects.filter(active=True)
+
 
 class AuthorIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.EdgeNgramField(document = True, use_template = True)


### PR DESCRIPTION
## Overview
This pull request introduces a small but important change to the `AppIndex` search index. The change ensures that only active `App` objects are included in the search index.

* Modified the `AppIndex` class in `apps/search_indexes.py` to filter the queryset so that only `App` objects with `active=True` are indexed.

## Related Issues
- #114