### PR TITLE
Fix #99: set fail_silently=True in CustomEmailHandler to prevent logg…

### DIFF
--- a/settings/admin_email_handler.py
+++ b/settings/admin_email_handler.py
@@ -5,5 +5,5 @@ from django.core import mail
 class CustomEmailHandler(AdminEmailHandler):
     def send_mail(self, subject, message, *args, **kwargs):
         # set fail_silently true before proceeding
-        kwargs["fail_silently"] = False
+        kwargs["fail_silently"] = True
         return super().send_mail(subject, message, *args, **kwargs)


### PR DESCRIPTION
…ing from stopping

When admin email delivery fails, the exception was propagating and halting the logging system entirely. The comment already stated the intent was fail_silently=True; the boolean was simply wrong.