### PR TITLE
Fix #82: replace releaseapi_set.get() with .all() to avoid MultipleOb…

### DIFF
--- a/apps/models.py
+++ b/apps/models.py
@@ -293,8 +293,7 @@ class Release(models.Model):
 
     def delete_files(self):
         self.release_file.delete()
-        if self.releaseapi_set.count() > 0:
-            api = self.releaseapi_set.get()
+        for api in self.releaseapi_set.all():
             api.delete_files()
             api.delete()
 


### PR DESCRIPTION
…jectsReturned

.get() raises MultipleObjectsReturned if more than one ReleaseAPI exists for a Release. Iterating over .all() handles any number of related objects.