### PR TITLE
Fix Django 5.0+ deprecation warnings for Django 5.2 LTS upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==4.2.15  # requires django.utils.importlib
+django==5.2  # Django 5.2 LTS
 social-auth-app-django==5.4.2
 sphinx
 urllib3
@@ -6,4 +6,3 @@ Whoosh==2.7.4
 django-haystack==3.3.0
 Pillow
 gevent
-

--- a/settings/base.py
+++ b/settings/base.py
@@ -27,10 +27,11 @@ SITE_ID = 1
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.
 USE_I18N = False
-
+USE_TZ = False
+# USE_L10N is deprecated since Django 5.0, localized formatting is always enabled
+# USE_L10N = False
 # If you set this to False, Django will not format dates, numbers and
 # calendars according to the current locale
-USE_L10N = False
 
 TEMPLATES = [
     {

--- a/util/id_util.py
+++ b/util/id_util.py
@@ -1,6 +1,6 @@
 import re
 
-_non_alphanum_re = re.compile(r'[W_]+')
+_non_alphanum_re = re.compile(r'[\W_]+')
 
 
 def fullname_to_name(fullname):

--- a/util/id_util.py
+++ b/util/id_util.py
@@ -1,6 +1,6 @@
 import re
 
-_non_alphanum_re = re.compile('[\W_]+')
+_non_alphanum_re = re.compile(r'[W_]+')
 
 
 def fullname_to_name(fullname):


### PR DESCRIPTION
## Summary
This PR fixes deprecation warnings that appear when running the AppStore 
with Django 5.0+ as part of the Django 5.2 LTS migration effort.

## Changes
- Removed deprecated `USE_L10N` setting (deprecated since Django 5.0, 
  localized formatting is now always enabled)
- Added explicit `USE_TZ = False` setting to maintain current behavior 
  (Django 5.0+ defaults USE_TZ to True)

## Testing
Verified no deprecation warnings with:
python -W all manage.py check --settings=settings.production