### PR TITLE
Fix ineffective conditional in search view (#136)

### DIFF
--- a/search/views.py
+++ b/search/views.py
@@ -74,6 +74,6 @@ def search(request):
         'search_query': query,
     	'go_back_to': '&ldquo;%s&rdquo; search results' % query,
     }
-    if None in (c['results']):
+    if c['results']:
         d = c
     return html_response('search.html', d, request, processors = (_nav_panel_context, ))


### PR DESCRIPTION
Fixes #136

### Problem
The condition `if None in c['results']` incorrectly checks for a key `None`, which always evaluates to False.

### Fix
Updated the condition to check whether the primary search results are non-empty.

### Result
Primary search results are now correctly prioritized over fallback results.