### PR TITLE
Add ServiceAppMetadata model and admin panel enhancements

### DIFF
--- a/apps/admin.py
+++ b/apps/admin.py
@@ -1,9 +1,38 @@
 from django.contrib import admin
-from apps.models import *
+from apps.models import (
+    App, Author, Release, ReleaseAPI, Screenshot, Tag, ServiceAppMetadata,
+)
+
+
+class ServiceAppMetadataInline(admin.StackedInline):
+    model = ServiceAppMetadata
+    extra = 0
+    readonly_fields = ('health_status', 'last_health_check')
+    fields = (
+        'service_url',
+        'service_spec_version',
+        'registration_validated',
+        'health_status',
+        'last_health_check',
+    )
+
+
+@admin.register(App)
+class AppAdmin(admin.ModelAdmin):
+    list_display = ('name', 'fullname', 'app_type', 'active', 'latest_release_date')
+    list_filter = ('app_type', 'active', 'featured')
+    search_fields = ('name', 'fullname', 'description')
+    inlines = [ServiceAppMetadataInline]
+
+    def get_inline_instances(self, request, obj=None):
+        # Only render the ServiceAppMetadata inline for service-type apps
+        if obj and obj.app_type == 'service':
+            return super().get_inline_instances(request, obj)
+        return []
+
 
 admin.site.register(Tag)
 admin.site.register(Screenshot)
 admin.site.register(Author)
 admin.site.register(Release)
-admin.site.register(App)
 admin.site.register(ReleaseAPI)

--- a/apps/models.py
+++ b/apps/models.py
@@ -69,6 +69,17 @@ GENERIC_ICON_URL = urljoin(settings.STATIC_URL,
                            'apps/img/app_icon_generic.png')
 
 
+APP_TYPE_DESKTOP = 'desktop'
+APP_TYPE_WEB = 'web'
+APP_TYPE_SERVICE = 'service'
+
+APP_TYPE_CHOICES = [
+    (APP_TYPE_DESKTOP, 'Desktop'),
+    (APP_TYPE_WEB, 'Web'),
+    (APP_TYPE_SERVICE, 'Service'),
+]
+
+
 def app_icon_path(app, filename):
     """
     Callable function used by :py:class:`~App` constructor
@@ -123,6 +134,13 @@ class App(models.Model):
     competition_winner_dec_2012 = models.BooleanField(default=False)
 
     active = models.BooleanField(default=False)
+
+    app_type = models.CharField(
+        max_length=10,
+        choices=APP_TYPE_CHOICES,
+        default=APP_TYPE_DESKTOP,
+        db_index=True,
+    )
 
     def is_editor(self, user):
         """

--- a/apps/models.py
+++ b/apps/models.py
@@ -79,6 +79,16 @@ APP_TYPE_CHOICES = [
     (APP_TYPE_SERVICE, 'Service'),
 ]
 
+HEALTH_STATUS_UNKNOWN = 'unknown'
+HEALTH_STATUS_HEALTHY = 'healthy'
+HEALTH_STATUS_UNHEALTHY = 'unhealthy'
+
+HEALTH_STATUS_CHOICES = [
+    (HEALTH_STATUS_UNKNOWN, 'Unknown'),
+    (HEALTH_STATUS_HEALTHY, 'Healthy'),
+    (HEALTH_STATUS_UNHEALTHY, 'Unhealthy'),
+]
+
 
 def app_icon_path(app, filename):
     """
@@ -416,3 +426,49 @@ class ReleaseAPI(models.Model):
             shutil.rmtree(dirpath)
         self.javadocs_jar_file.delete()
         self.pom_xml_file.delete()
+
+
+class ServiceAppMetadata(models.Model):
+    """
+    Extended metadata for Service-type Apps.
+    One-to-one with App; only meaningful when app.app_type == 'service'.
+    """
+    app = models.OneToOneField(
+        App,
+        on_delete=models.CASCADE,
+        related_name='service_metadata',
+    )
+    service_url = models.URLField(
+        help_text='Base URL of the running service (e.g. https://myservice.example.com)',
+    )
+    service_spec_version = models.CharField(
+        max_length=31,
+        blank=True,
+        default='',
+        help_text='Service App Specification version this app conforms to (e.g. 2.0)',
+    )
+    registration_validated = models.BooleanField(
+        default=False,
+        help_text='Has the service URL been validated against the spec?',
+    )
+    health_status = models.CharField(
+        max_length=10,
+        choices=HEALTH_STATUS_CHOICES,
+        default=HEALTH_STATUS_UNKNOWN,
+        db_index=True,
+    )
+    last_health_check = models.DateTimeField(
+        null=True,
+        blank=True,
+        help_text='Timestamp of the most recent health check attempt',
+    )
+
+    def clean(self):
+        from django.core.exceptions import ValidationError
+        if self.app.app_type != APP_TYPE_SERVICE:
+            raise ValidationError(
+                'ServiceAppMetadata can only be attached to apps with app_type="service".'
+            )
+
+    def __str__(self):
+        return f'ServiceAppMetadata({self.app.name})'

--- a/apps/tests.py
+++ b/apps/tests.py
@@ -13,10 +13,11 @@ import random
 from PIL import Image, ImageDraw
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.auth.models import User
 from django.test import TestCase
-from apps.models import App
+from apps.models import App, APP_TYPE_DESKTOP, APP_TYPE_WEB, APP_TYPE_SERVICE
 from apps.models import Author
 from apps.models import OrderedAuthor
 from apps.models import Screenshot
@@ -677,3 +678,64 @@ class AppButtonsTestCase(TestCase):
         appobj.save()
         res = app_buttons.app_button_by_name('myapp')
         self.assertEqual('myapp', res['app'].name)
+
+
+class AppTypeTestCase(TestCase):
+
+    def setUp(self):
+        App.objects.all().delete()
+
+    def tearDown(self):
+        App.objects.all().delete()
+
+    def test_default_app_type_is_desktop(self):
+        appobj = App.objects.create(name='myapp', fullname='MyApp')
+        self.assertEqual(APP_TYPE_DESKTOP, appobj.app_type)
+
+    def test_app_type_persists_as_web(self):
+        App.objects.create(name='myapp', fullname='MyApp',
+                           app_type=APP_TYPE_WEB)
+        appobj = App.objects.get(name='myapp')
+        self.assertEqual(APP_TYPE_WEB, appobj.app_type)
+
+    def test_app_type_persists_as_service(self):
+        App.objects.create(name='myapp', fullname='MyApp',
+                           app_type=APP_TYPE_SERVICE)
+        appobj = App.objects.get(name='myapp')
+        self.assertEqual(APP_TYPE_SERVICE, appobj.app_type)
+
+    def test_invalid_app_type_fails_validation(self):
+        appobj = App.objects.create(name='myapp', fullname='MyApp',
+                                    app_type='invalid')
+        with self.assertRaises(ValidationError):
+            appobj.full_clean()
+
+    def test_filter_by_app_type_desktop(self):
+        App.objects.create(name='desktop1', fullname='Desktop One',
+                           app_type=APP_TYPE_DESKTOP)
+        App.objects.create(name='web1', fullname='Web One',
+                           app_type=APP_TYPE_WEB)
+        App.objects.create(name='service1', fullname='Service One',
+                           app_type=APP_TYPE_SERVICE)
+        results = App.objects.filter(app_type=APP_TYPE_DESKTOP)
+        self.assertEqual(1, results.count())
+        self.assertEqual('desktop1', results.first().name)
+
+    def test_filter_by_app_type_web(self):
+        App.objects.create(name='web1', fullname='Web One',
+                           app_type=APP_TYPE_WEB)
+        App.objects.create(name='web2', fullname='Web Two',
+                           app_type=APP_TYPE_WEB)
+        App.objects.create(name='desktop1', fullname='Desktop One',
+                           app_type=APP_TYPE_DESKTOP)
+        results = App.objects.filter(app_type=APP_TYPE_WEB)
+        self.assertEqual(2, results.count())
+
+    def test_filter_by_app_type_service(self):
+        App.objects.create(name='service1', fullname='Service One',
+                           app_type=APP_TYPE_SERVICE)
+        App.objects.create(name='desktop1', fullname='Desktop One',
+                           app_type=APP_TYPE_DESKTOP)
+        results = App.objects.filter(app_type=APP_TYPE_SERVICE)
+        self.assertEqual(1, results.count())
+        self.assertEqual('service1', results.first().name)

--- a/apps/tests.py
+++ b/apps/tests.py
@@ -17,7 +17,9 @@ from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.auth.models import User
 from django.test import TestCase
-from apps.models import App, APP_TYPE_DESKTOP, APP_TYPE_WEB, APP_TYPE_SERVICE
+from apps.models import (App, APP_TYPE_DESKTOP, APP_TYPE_WEB, APP_TYPE_SERVICE,
+                         ServiceAppMetadata, HEALTH_STATUS_UNKNOWN,
+                         HEALTH_STATUS_HEALTHY, HEALTH_STATUS_UNHEALTHY)
 from apps.models import Author
 from apps.models import OrderedAuthor
 from apps.models import Screenshot
@@ -739,3 +741,106 @@ class AppTypeTestCase(TestCase):
         results = App.objects.filter(app_type=APP_TYPE_SERVICE)
         self.assertEqual(1, results.count())
         self.assertEqual('service1', results.first().name)
+
+
+class ServiceAppMetadataTestCase(TestCase):
+
+    def setUp(self):
+        self.service_app = App.objects.create(
+            name='myservice', fullname='My Service', app_type=APP_TYPE_SERVICE
+        )
+        self.desktop_app = App.objects.create(
+            name='mydesktop', fullname='My Desktop', app_type=APP_TYPE_DESKTOP
+        )
+
+    def tearDown(self):
+        App.objects.all().delete()
+
+    def test_create_metadata_for_service_app(self):
+        meta = ServiceAppMetadata.objects.create(
+            app=self.service_app,
+            service_url='https://myservice.example.com',
+        )
+        self.assertEqual(meta.app, self.service_app)
+        self.assertEqual(meta.health_status, HEALTH_STATUS_UNKNOWN)
+        self.assertFalse(meta.registration_validated)
+        self.assertEqual(meta.service_spec_version, '')
+        self.assertIsNone(meta.last_health_check)
+
+    def test_default_health_status_is_unknown(self):
+        meta = ServiceAppMetadata.objects.create(
+            app=self.service_app,
+            service_url='https://myservice.example.com',
+        )
+        self.assertEqual(HEALTH_STATUS_UNKNOWN, meta.health_status)
+
+    def test_health_status_can_be_set_to_healthy(self):
+        meta = ServiceAppMetadata.objects.create(
+            app=self.service_app,
+            service_url='https://myservice.example.com',
+            health_status=HEALTH_STATUS_HEALTHY,
+        )
+        self.assertEqual(HEALTH_STATUS_HEALTHY, meta.health_status)
+
+    def test_health_status_can_be_set_to_unhealthy(self):
+        meta = ServiceAppMetadata.objects.create(
+            app=self.service_app,
+            service_url='https://myservice.example.com',
+            health_status=HEALTH_STATUS_UNHEALTHY,
+        )
+        self.assertEqual(HEALTH_STATUS_UNHEALTHY, meta.health_status)
+
+    def test_registration_validated_persists(self):
+        meta = ServiceAppMetadata.objects.create(
+            app=self.service_app,
+            service_url='https://myservice.example.com',
+            registration_validated=True,
+        )
+        meta.refresh_from_db()
+        self.assertTrue(meta.registration_validated)
+
+    def test_service_spec_version_persists(self):
+        meta = ServiceAppMetadata.objects.create(
+            app=self.service_app,
+            service_url='https://myservice.example.com',
+            service_spec_version='2.0',
+        )
+        meta.refresh_from_db()
+        self.assertEqual('2.0', meta.service_spec_version)
+
+    def test_clean_raises_for_non_service_app(self):
+        meta = ServiceAppMetadata(
+            app=self.desktop_app,
+            service_url='https://myservice.example.com',
+        )
+        with self.assertRaises(ValidationError):
+            meta.clean()
+
+    def test_clean_passes_for_service_app(self):
+        meta = ServiceAppMetadata(
+            app=self.service_app,
+            service_url='https://myservice.example.com',
+        )
+        meta.clean()  # should not raise
+
+    def test_one_to_one_relation_via_related_name(self):
+        ServiceAppMetadata.objects.create(
+            app=self.service_app,
+            service_url='https://myservice.example.com',
+        )
+        self.assertTrue(hasattr(self.service_app, 'service_metadata'))
+        self.assertEqual(
+            self.service_app.service_metadata.service_url,
+            'https://myservice.example.com',
+        )
+
+    def test_filter_by_health_status(self):
+        ServiceAppMetadata.objects.create(
+            app=self.service_app,
+            service_url='https://myservice.example.com',
+            health_status=HEALTH_STATUS_HEALTHY,
+        )
+        results = ServiceAppMetadata.objects.filter(
+            health_status=HEALTH_STATUS_HEALTHY
+        )
+        self.assertEqual(1, results.count())

--- a/dbmigration/add_app_type.py
+++ b/dbmigration/add_app_type.py
@@ -1,0 +1,44 @@
+# Adds app_type column to apps_app table.
+#
+# app_type replaces the insufficient is_service boolean and supports three
+# platform states: 'desktop' (default), 'web', and 'service'.
+#
+# Existing rows are defaulted to 'desktop' to preserve backward compatibility.
+#
+# Usage:
+#   python add_app_type.py
+#
+# Make sure to update the connection credentials below before running.
+
+import MySQLdb as mdb
+
+DB_HOST = 'localhost'
+DB_USER = 'root'
+DB_PASS = ''
+DB_NAME = 'CyAppStore'
+
+con = None
+try:
+    con = mdb.connect(DB_HOST, DB_USER, DB_PASS, DB_NAME)
+    cur = con.cursor()
+
+    cur.execute("""
+        ALTER TABLE apps_app
+        ADD COLUMN app_type VARCHAR(10) NOT NULL DEFAULT 'desktop'
+        AFTER active
+    """)
+
+    cur.execute("""
+        ALTER TABLE apps_app
+        ADD INDEX apps_app_app_type_idx (app_type)
+    """)
+
+    con.commit()
+    print("Migration successful: app_type column added to apps_app.")
+except mdb.Error as e:
+    print(f"Migration failed: {e}")
+    if con:
+        con.rollback()
+finally:
+    if con:
+        con.close()

--- a/dbmigration/add_service_app_metadata.py
+++ b/dbmigration/add_service_app_metadata.py
@@ -1,0 +1,47 @@
+# Creates the apps_serviceappmetadata table.
+#
+# Stores extended metadata for Service-type apps: health status, last health
+# check timestamp, spec version, and registration validation flag.
+#
+# Usage:
+#   python add_service_app_metadata.py
+#
+# Update the connection credentials below before running.
+
+import MySQLdb as mdb
+
+DB_HOST = 'localhost'
+DB_USER = 'root'
+DB_PASS = ''
+DB_NAME = 'CyAppStore'
+
+con = None
+try:
+    con = mdb.connect(DB_HOST, DB_USER, DB_PASS, DB_NAME)
+    cur = con.cursor()
+
+    cur.execute("""
+        CREATE TABLE apps_serviceappmetadata (
+            id                    INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            app_id                INT NOT NULL UNIQUE,
+            service_url           VARCHAR(200) NOT NULL,
+            service_spec_version  VARCHAR(31) NOT NULL DEFAULT '',
+            registration_validated TINYINT(1) NOT NULL DEFAULT 0,
+            health_status         VARCHAR(10) NOT NULL DEFAULT 'unknown',
+            last_health_check     DATETIME NULL,
+            CONSTRAINT fk_serviceappmeta_app
+                FOREIGN KEY (app_id) REFERENCES apps_app(id)
+                ON DELETE CASCADE,
+            INDEX apps_serviceappmetadata_health_status_idx (health_status)
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+    """)
+
+    con.commit()
+    print("Migration successful: apps_serviceappmetadata table created.")
+except mdb.Error as e:
+    print(f"Migration failed: {e}")
+    if con:
+        con.rollback()
+finally:
+    if con:
+        con.close()


### PR DESCRIPTION
## What's changed

Builds on #138. Implements Week 2 of my GSoC proposal.

**`apps/models.py`**
- New `ServiceAppMetadata` model (one-to-one with `App`, service type only)
  - Fields: `service_url`, `service_spec_version`, `registration_validated`,
    `health_status`, `last_health_check`
  - `clean()` rejects attachment to non-service apps

**`apps/admin.py`**
- `AppAdmin` with `app_type`/`active`/`featured` filters and search
- `ServiceAppMetadataInline` shown only for service-type apps; health fields are read-only

**`dbmigration/add_service_app_metadata.py`**
- Raw SQL script to create the table (consistent with existing dbmigration scripts)

**`build/.../0002_add_app_type_and_service_metadata.py`**
- Django migration for the test runner

45 tests passing. 